### PR TITLE
Add CacheMethod.config.default_generational_ttl

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -197,6 +197,10 @@ You can disable it to get a little speed boost
 
     CacheMethod.config.generational = false
 
+Generational caching stores a separate generation key that never expires by default. To set a default TTL for these
+
+    CacheMethod.config.default_generational_ttl = 120
+
 ## Debug
 
 CacheMethod can warn you if your obj or args cache keys are suspiciously long.

--- a/lib/cache_method/config.rb
+++ b/lib/cache_method/config.rb
@@ -63,5 +63,17 @@ module CacheMethod
     def default_ttl #:nodoc:
       @default_ttl || 86_400
     end
+
+    # TTL for method generational caches. Defaults to 0 (never).
+    #
+    # Example:
+    #     CacheMethod.config.default_generational_ttl = 120 # seconds
+    def default_generational_ttl=(seconds)
+      @default_generational_ttl = seconds
+    end
+
+    def default_generational_ttl #:nodoc:
+      @default_generational_ttl || 0
+    end
   end
 end

--- a/lib/cache_method/generation.rb
+++ b/lib/cache_method/generation.rb
@@ -41,8 +41,7 @@ module CacheMethod
 
     def set
       random_name = ::Kernel.rand(1e11).to_s
-      # never expire!
-      CacheMethod.config.storage.set cache_key, random_name, 0
+      CacheMethod.config.storage.set cache_key, random_name, CacheMethod.config.default_generational_ttl
       random_name
     end
   end


### PR DESCRIPTION
I did some digging on #9 and found the reason we were seeing left over generational keys is from our usage of `as_cache_key`.

We have something like this in our app:

``` ruby
class Post < ActiveRecord::Base
  def as_cache_key
    { id: id, updated_at: updated_at.try(:utc) }
  end
end
```

The intention here was to generate a new cache key when the model was updated. That works, but it creates a new cached result and generation. The old result expires, and the old generation sticks around in the cache because its TTL is 0.

This PR adds an option to specify a TTL for generations via `CacheMethod.config.default_generational_ttl`. This allows overriding the default behavior to make generations expire.

Just a note from testing, if the generation expires before the cached result, this results in a cache miss the next time a cached method is run and a new cached result/generation are cached. If the cached result expires first, the same thing happens.
