### PR TITLE
Add ruby 3.x support for separately-tracked kwargs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+0.3.0 / 2022-10-16
+
+* Enhancements
+
+  * Ruby 3.x support
+
+* Breaking changes
+
+  * Cache key format changed to include kwargs; existing caches will be invalidated on upgrade
+
 0.2.7 / 2015-04-03
 
 * Enhancements

--- a/lib/cache_method.rb
+++ b/lib/cache_method.rb
@@ -72,8 +72,8 @@ module CacheMethod
       end
     end
 
-    def cache_method_cached?(method_id, *args)
-      ::CacheMethod::CachedResult.new(self, method_id, nil, nil, args).exist?
+    def cache_method_cached?(method_id, *args, **kwargs)
+      ::CacheMethod::CachedResult.new(self, method_id, nil, nil, args, kwargs).exist?
     end
   end
 
@@ -95,8 +95,8 @@ module CacheMethod
     def cache_method(method_id, ttl = nil)
       original_method_id = "_cache_method_#{method_id}"
       alias_method original_method_id, method_id
-      define_method method_id do |*args, &blk|
-        ::CacheMethod::CachedResult.new(self, method_id, original_method_id, ttl, args, &blk).fetch
+      define_method method_id do |*args, **kwargs, &blk|
+        ::CacheMethod::CachedResult.new(self, method_id, original_method_id, ttl, args, kwargs, &blk).fetch
       end
     end
 
@@ -118,9 +118,9 @@ module CacheMethod
       original_method_id = "_cache_method_clear_on_#{method_id}"
       alias_method original_method_id, method_id
 
-      define_method method_id do |*args, &blk|
+      define_method method_id do |*args, **kwargs, &blk|
         cache_method_clear cache_method_clear_id
-        send(original_method_id, *args, &blk)
+        send(original_method_id, *args, **kwargs, &blk)
       end
     end
   end

--- a/lib/cache_method/debug.rb
+++ b/lib/cache_method/debug.rb
@@ -10,16 +10,24 @@ module CacheMethod
   end
 
   class CachedResult
+    def args_string
+      if kwargs.empty?
+        args.inspect
+      else
+        "#{args.inspect}, #{kwargs.inspect}"
+      end
+    end
+
     def debug_get_wrapped
       retval = original_get_wrapped
       if retval
         # $stderr.puts
-        # $stderr.puts "[cache_method] GET: #{method_signature}(#{args.inspect})"
+        # $stderr.puts "[cache_method] GET: #{method_signature}(#{args_string})"
       else
         cache_key = CacheMethod.resolve_cache_key obj
         m = Marshal.dump cache_key
         $stderr.puts
-        $stderr.puts "[cache_method] GET (miss!): #{method_signature}(#{args.inspect}) - #{::Digest::SHA1.hexdigest(m)} - #{cache_key.inspect}"
+        $stderr.puts "[cache_method] GET (miss!): #{method_signature}(#{args_string}) - #{::Digest::SHA1.hexdigest(m)} - #{cache_key.inspect}"
       end
       retval
     end
@@ -31,10 +39,10 @@ module CacheMethod
       m = Marshal.dump retval
       if m.length > 1000
         $stderr.puts
-        $stderr.puts "[cache_method] SET (#{'X' * (m.length / 1024)}): #{method_signature}(#{args.inspect}) -> #{retval.inspect}"
+        $stderr.puts "[cache_method] SET (#{'X' * (m.length / 1024)}): #{method_signature}(#{args_string}) -> #{retval.inspect}"
       else
         # $stderr.puts
-        # $stderr.puts "[cache_method] SET: #{method_signature}(#{args.inspect})"
+        # $stderr.puts "[cache_method] SET: #{method_signature}(#{args_string})"
       end
       retval
     end

--- a/lib/cache_method/version.rb
+++ b/lib/cache_method/version.rb
@@ -1,3 +1,3 @@
 module CacheMethod
-  VERSION = "0.2.7"
+  VERSION = "0.3.0"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -99,6 +99,30 @@ class CopyCat2
   end
 end
 
+class CopyCat3
+  attr_reader :name
+  def initialize(name)
+    @name = name
+  end
+  attr_writer :echo_count
+  def echo_count
+    @echo_count ||= 0
+  end
+  def echo(*args, **kwargs)
+    self.echo_count += 1
+    return { args: args, kwargs: kwargs }
+  end
+  attr_writer :ack_count
+  def marshal_dump
+    raise "Used marshal_dump"
+  end
+  def as_cache_key
+    name
+  end
+  cache_method :echo
+end
+
+
 class Blog1
   attr_reader :name
   attr_reader :url
@@ -120,11 +144,11 @@ class Blog1
     ["voo vaa #{name}"]
   end
   cache_method :get_latest_entries2, 1 # second
-  def update_entries param
+  def update_entries param, kwparam:
     if block_given?
-      yield param
+      yield [param, kwparam]
     else
-      param
+      [param, kwparam]
     end
   end
   cache_method_clear_on :update_entries, :get_latest_entries

--- a/test/test_cache_method.rb
+++ b/test/test_cache_method.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 
 require 'dalli'
 
@@ -181,6 +181,20 @@ describe CacheMethod do
     end
   end
 
+  it %{cache_class_method_with_kwargs} do
+    a = CopyCat3.new 'mimo'
+
+    a.echo('hi', 'there', kw1: 'a', kw2: 'b').must_equal({ args: ['hi', 'there'], kwargs: {kw1: 'a', kw2: 'b'} })
+    a.echo_count.must_equal 1
+
+    a.echo('hi', 'there', kw1: 'a', kw2: 'b').must_equal({ args: ['hi', 'there'], kwargs: {kw1: 'a', kw2: 'b'} })
+    a.echo_count.must_equal 1
+
+    # ensure kwargs are part of key
+    a.echo('hi', 'there', kw1: 'c', kw2: 'd').must_equal({ args: ['hi', 'there'], kwargs: {kw1: 'c', kw2: 'd'} })
+    a.echo_count.must_equal 2
+  end
+
   it %{cache_instance_method} do
     a = new_instance_of_my_blog
     a.get_latest_entries.must_equal ["hello from #{a.name}"]
@@ -208,8 +222,9 @@ describe CacheMethod do
     a = new_instance_of_my_blog
     a.get_latest_entries.must_equal ["hello from #{a.name}"]
     a.request_count.must_equal 1
-    a.update_entries("param").must_equal("param")
-    a.update_entries(1) {|param| param + 1}.must_equal(2)
+    a.update_entries("param", kwparam: 'kwparam').must_equal(["param", "kwparam"])
+    a.update_entries(1, kwparam: 'a') {|param, kwparam| param + 1}.must_equal(2)
+    a.update_entries(1, kwparam: 'a') {|param, kwparam| kwparam}.must_equal('a')
     a.get_latest_entries.must_equal ["hello from #{a.name}"]
     a.request_count.must_equal 2
     a.get_latest_entries.must_equal ["hello from #{a.name}"]


### PR DESCRIPTION
Teach cache_method to track kwargs separately from args, rather than treating them as a hash arg in the final position.

Fixes #17 